### PR TITLE
Add elasticsearch to the list of services

### DIFF
--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -52,6 +52,14 @@
     - { role: debops.postgresql, tags: postgresql }
 
 
+- name: Manage Elasticsearch server
+  hosts: 'debops_elasticsearch_master:debops_elasticsearch_workhorse:debops_elasticsearch_coordinator:debops_elasticsearch_loadbalancer'
+  sudo: True
+
+  roles:
+    - { role: debops.elasticsearch, tags: elasticsearch }
+
+
 - name: Manage Redis server
   hosts: 'debops_redis'
   sudo: True


### PR DESCRIPTION
The role can be found at:
https://github.com/debops/ansible-elasticsearch
