### PR TITLE
Add 'roles/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore user-created DebOps directories
 playbooks/roles
+roles
 inventory
 inventory.secret
 


### PR DESCRIPTION
'roles/' directory will be used as the directory where roles are
installed. This will allow easy override of upstream DebOps roles by
roles in project directory.
