### PR TITLE
Fixing readme empty table cell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ LXC_ OpenVZ_ KVM_
 **Backup and encryption**
 
 ========= ========== ====== ==== =============
-Safekeep_ BoxBackup_   encFS_ SKS_ Monkeysphere_
+Safekeep_ BoxBackup_ encFS_ SKS_ Monkeysphere_
 ========= ========== ====== ==== =============
 
 Overview of how playbooks work within DebOps


### PR DESCRIPTION
There was an empty table cell under the "Backup and Encryption" header.
