### PR TITLE
Do not use ansible_ssh_user as admin user

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -31,7 +31,7 @@
   sudo: False
 
   vars:
-    bootstrap_admin_account: '{{ ansible_ssh_user | default(lookup("env","USER")) }}'
+    bootstrap_admin_account: '{{ lookup("env","USER") }}'
     bootstrap_admin_group: 'admins'
     bootstrap_admin_ssh_key: '{{ lookup("pipe","ssh-add -L") }}'
 


### PR DESCRIPTION
If one does not have any user on the host, he connects
with root. Then the remote user is root, and ansible_ssh_user seems to
represent the remote user.