### PR TITLE
Add new root.yml paths and preserve defined

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,27 @@ This is a Changelog related to DebOps_ playbooks and roles. You can also read
 .. _DebOps Changelog: https://github.com/debops/debops/blob/master/CHANGELOG.md
 
 
-v0.1.0 (release pending)
-------------------------
+v0.2.0 (unreleased)
+-------------------
+
+
+v0.1.0 (2015-02-16)
+-------------------
+
+- Format of the Changelog is modified to reflect new versioning. Old entries are
+  preserved. [drybjed]
+
+- ``ansible_local.root.home`` default path has been changed from ``/var/lib``
+  to ``/var/local`` to move home directories out of the way of the system
+  packages. [drybjed]
+
+- New paths have been added to ``root.yml`` service paths. [drybjed]
+
+- ``root.yml`` service paths that are already configured on remote host as facts will
+  override playbook or inventory changes to protect already installed services
+  from future changes. [drybjed]
+
+****
 
 2015-02-12
 ^^^^^^^^^^

--- a/playbooks/root.yml
+++ b/playbooks/root.yml
@@ -33,9 +33,33 @@
     # You can override these variables in Ansible inventory.
     root_service_directories:
 
-        # Path for service home directories
-      - path: '{{ root_service_home   | default("/var/lib")     }}'
-        fact: 'home'
+        # Path for local Ansible Facts
+      - path: '/etc/ansible/facts.d'
+        fact: 'facts'
+
+        # Path for local service binaries
+      - path: '{{ root_service_bin   | default("/usr/local/bin") }}'
+        fact: 'bin'
+
+        # Path for local service configuration
+      - path: '{{ root_service_etc   | default("/usr/local/etc") }}'
+        fact: 'etc'
+
+        # Path for service static library directories
+      - path: '{{ root_service_lib   | default("/usr/local/lib") }}'
+        fact: 'lib'
+
+        # Path for local service privileged binaries
+      - path: '{{ root_service_sbin   | default("/usr/local/sbin") }}'
+        fact: 'sbin'
+
+        # Path for service static data
+      - path: '{{ root_service_share  | default("/usr/local/share") }}'
+        fact: 'share'
+
+        # Path for local sources (cloned git repositories, etc.)
+      - path: '{{ root_service_src    | default("/usr/local/src") }}'
+        fact: 'src'
 
         # Path for local data directories
       - path: '{{ root_service_data   | default("/srv")         }}'
@@ -45,19 +69,18 @@
       - path: '{{ root_service_backup | default("/var/backups") }}'
         fact: 'backup'
 
-        # Path for local sources (cloned git repositories, etc.)
-      - path: '{{ root_service_src    | default("/usr/local/src") }}'
-        fact: 'src'
+        # Path for local service home directories and internal state data
+      - path: '{{ root_service_home   | default("/var/local") }}'
+        fact: 'home'
+
 
   tasks:
 
     - name: Create root directories
       file:
-        path: '{{ item }}'
+        path: '{{ hostvars[inventory_hostname]["ansible_local"]["root"][item.fact] if (hostvars[inventory_hostname]["ansible_local"] is defined and hostvars[inventory_hostname]["ansible_local"]["root"] is defined and hostvars[inventory_hostname]["ansible_local"]["root"][item.fact] is defined) else item.path }}'
         state: 'directory'
-      with_flattened:
-        - '/etc/ansible/facts.d'
-        - '{{ root_service_directories | map(attribute="path") | list }}'
+      with_items: root_service_directories
 
     - name: Save root local facts
       template:

--- a/playbooks/templates/etc/ansible/facts.d/root.fact.j2
+++ b/playbooks/templates/etc/ansible/facts.d/root.fact.j2
@@ -1,7 +1,13 @@
 {
 "uuid": "{{ ansible_local.root.uuid if (ansible_local is defined and ansible_local.root is defined and ansible_local.root.uuid is defined) else root_uuid_random_source }}",
 {% for item in root_service_directories %}
+{% if hostvars[inventory_hostname]["ansible_local"] is defined and
+      hostvars[inventory_hostname]["ansible_local"]["root"] is defined and
+      hostvars[inventory_hostname]["ansible_local"]["root"][item.fact] is defined %}
+"{{ item.fact }}": "{{ hostvars[inventory_hostname]["ansible_local"]["root"][item.fact] }}"{% if not loop.last %},{% endif %}
+{% else %}
 "{{ item.fact }}": "{{ item.path }}"{% if not loop.last %},{% endif %}
+{% endif %}
 
 {% endfor %}
 }


### PR DESCRIPTION
Changes in playbook or inventory that redefine 'root.yml' paths won't
affect existing installation anymore.

Default service home directory has been changed from '/var/lib' to
'/var/local' to avoid collisions with system packages in the future.