### PR TITLE
s/bootstrap_hostname/inventory_hostname in bootstrap.yml comments

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -17,7 +17,7 @@
 #     inventory-file).
 #   - no passwords are set or modified on any account;
 #   - if set, playbook will configure hostname and domain on the host using
-#     'bootstrap_hostname' and 'bootstrap_domain' variables;
+#     'inventory_hostname' and 'bootstrap_domain' variables;
 #
 # Usage:
 # To connect directly as root, run:


### PR DESCRIPTION
There is no `bootstrap_hostname` var