### PR TITLE
Populate and update package index files before installing

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -91,6 +91,9 @@
     # Specify 'bootstrap_domain' in inventory to set a domain
 
   tasks:
+  - name: Populate and update the package index files
+    raw: apt-get update
+
   - name: Install minimal Python support for Ansible
     raw: apt-get --no-install-recommends -yq install python python-apt libcap2-bin
 


### PR DESCRIPTION
Some vendors (at Ubuntu on DigitalOcean) don't have the package index files populated until apt-get update is first run.
And getting fresh packages on first install is good anyway.