### PR TITLE
Followup to Convert Changelog to reStructuredText

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ DebOps playbooks Changelog
 This is a Changelog related to DebOps_ playbooks and roles. You can also read
 `DebOps Changelog`_ to see changes to the DebOps project itself.
 
-.. _DebOps Changelog: https://github.com/debops/debops/blob/master/CHANGELOG.md
+.. _DebOps Changelog: https://github.com/debops/debops/blob/master/CHANGES.rst
 
 
 v0.2.8


### PR DESCRIPTION
Fix the Link to point to CHANGES.rst inside the debobs script repo as CHANGELOG.md was converted