### PR TITLE
Removed sshkeys role from `common.yml` as it is included in `debops.sshd`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ v0.2.8
 - Add ``debops.dhparam`` role, included in the ``common.yml`` playbook by
   default. [drybjed]
 
+- Removed ``debops.sshkeys`` role from ``common.yml`` as it is included in
+  ``debops.sshd`` as role dependency. [ypid]
+
 v0.2.7
 ------
 

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -53,9 +53,6 @@
     - role: debops.users
       tags: [ 'users', 'role::users' ]
 
-    - role: debops.sshkeys
-      tags: [ 'sshkeys', 'role::sshkeys' ]
-
     - role: debops.sshd
       tags: [ 'sshd', 'role::sshd' ]
 


### PR DESCRIPTION
The role `debops.sshkeys` is run two times in the common.yml playbook
directly after each other. The first time directly, the second time as
role dependency from `debops.sshd`
https://github.com/debops/ansible-sshd/blob/9c5c038b8d61db3f9e38e4d787d6ba4e2f4773cb/meta/main.yml#L62

Or am I missing something?