### PR TITLE
Update common and service/pki.yml playbooks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,6 +89,9 @@ v0.2.8
 
 - Add missing ``ferm`` configuration for ``debops.postfix`` role. [drybjed]
 
+- Update the ``common.yml`` playbook and ``service/pki.yml`` playbook with new
+  ``debops.pki`` role requirements. [drybjed]
+
 v0.2.7
 ------
 

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -8,6 +8,15 @@
   become: True
 
   roles:
+
+    - role: debops.pki/env
+      tags: [ 'role::pki', 'role::secret' ]
+
+    - role: debops.secret
+      tags: [ 'role::secret', 'role::pki' ]
+      secret_directories:
+        - '{{ pki_env_secret_directories }}'
+
     - role: debops.apt_preferences
       tags: [ 'apt_preferences', 'role::apt_preferences' ]
       apt_preferences_dependent_list:

--- a/playbooks/service/pki.yml
+++ b/playbooks/service/pki.yml
@@ -6,6 +6,14 @@
 
   roles:
 
+    - role: debops.pki/env
+      tags: [ 'role::pki', 'role::secret' ]
+
+    - role: debops.secret
+      secret_directories:
+        - '{{ pki_env_secret_directories }}'
+      tags: [ 'role::secret' ]
+
     - role: debops.pki
       tags: [ 'role::pki' ]
 


### PR DESCRIPTION
The new 'debops.pki' role has additional required roles that need to be
executed before it.