### PR TITLE
Moved roles dependencies from `debops.subnetwork` to subnetwork playbook.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ v0.2.9
 - Update the ``service/mailman.yml`` playbook with support for new
   ``debops.mailman`` release. [drybjed]
 
+- Moved roles dependencies from ``debops.subnetwork`` to subnetwork playbook. [ypid]
+
 v0.2.8
 ------
 

--- a/playbooks/service/subnetwork.yml
+++ b/playbooks/service/subnetwork.yml
@@ -6,6 +6,19 @@
 
   roles:
 
+    - role: debops.subnetwork/env
+      tags: [ 'role::subnetwork' ]
+
+    - role: debops.ifupdown
+      tags: [ 'role::ifupdown' ]
+      ifupdown_dependent_interfaces: '{{ subnetwork__ifupdown__dependent_list }}'
+
+    - role: debops.ferm
+      tags: [ 'role::ferm' ]
+      ferm_forward: '{{ subnetwork__kernel_forwarding|d() | bool }}'
+      ferm_dependent_rules:
+        - '{{ subnetwork__ferm__dependent_rules }}'
+
     - role: debops.subnetwork
       tags: [ 'role::subnetwork' ]
 


### PR DESCRIPTION
Related to https://github.com/debops/ansible-subnetwork/pull/10.