### PR TITLE
Updated to reworked `debops.apt` role. Namespacing updates.

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -19,7 +19,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'apt_preferences', 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ sshd__apt_preferences__dependent_list }}'
         - '{{ apt__apt_preferences__dependent_list }}'
 

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -21,6 +21,7 @@
       tags: [ 'apt_preferences', 'role::apt_preferences' ]
       apt_preferences_dependent_list:
         - '{{ sshd__apt_preferences__dependent_list }}'
+        - '{{ apt__apt_preferences__dependent_list }}'
 
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -43,7 +43,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ ntp_ferm_dependent_rules }}'
         - '{{ postfix_ferm_dependent_rules }}'
         - '{{ sshd__ferm__dependent_rules }}'

--- a/playbooks/service/apt_cacher_ng.yml
+++ b/playbooks/service/apt_cacher_ng.yml
@@ -21,11 +21,6 @@
       ferm__dependent_rules:
         - '{{ apt_cacher_ng__ferm__dependent_rules }}'
 
-    - role: debops.ferm
-      tags: [ 'role::ferm' ]
-      ferm__dependent_rules:
-        - '{{ apt_cacher_ng__ferm__dependent_rules }}'
-
     # - role: debops.contrib-apparmor
     #   tags: [ 'role::apparmor' ]
     #   apparmor__local_dependent_config: '{{ apt_cacher_ng__apparmor__dependent_config }}'

--- a/playbooks/service/docker.yml
+++ b/playbooks/service/docker.yml
@@ -8,7 +8,7 @@
 
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]
-      etc_services_dependent_list:
+      etc_services__dependent_list:
         - '{{ docker_etc_services_dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/docker.yml
+++ b/playbooks/service/docker.yml
@@ -13,7 +13,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ docker_ferm_dependent_rules }}'
 
     - role: debops.docker

--- a/playbooks/service/mailman.yml
+++ b/playbooks/service/mailman.yml
@@ -23,7 +23,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ postfix_ferm_dependent_rules }}'
         - '{{ nginx_ferm_dependent_rules }}'
 

--- a/playbooks/service/mailman.yml
+++ b/playbooks/service/mailman.yml
@@ -17,7 +17,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ mailman__apt_preferences__dependent_list }}'
         - '{{ nginx_apt_preferences_dependent_list }}'
 

--- a/playbooks/service/nginx.yml
+++ b/playbooks/service/nginx.yml
@@ -8,7 +8,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ nginx_apt_preferences_dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/nginx.yml
+++ b/playbooks/service/nginx.yml
@@ -13,7 +13,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ nginx_ferm_dependent_rules }}'
 
     - role: debops.nginx

--- a/playbooks/service/ntp.yml
+++ b/playbooks/service/ntp.yml
@@ -8,7 +8,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ ntp_ferm_dependent_rules }}'
 
     - role: debops.ntp

--- a/playbooks/service/owncloud.yml
+++ b/playbooks/service/owncloud.yml
@@ -36,7 +36,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ nginx_apt_preferences_dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/owncloud.yml
+++ b/playbooks/service/owncloud.yml
@@ -41,7 +41,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ nginx_ferm_dependent_rules }}'
 
     - role: debops.nginx

--- a/playbooks/service/postfix.yml
+++ b/playbooks/service/postfix.yml
@@ -8,7 +8,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ postfix_ferm_dependent_rules }}'
 
     - role: debops.postfix

--- a/playbooks/service/postgresql.yml
+++ b/playbooks/service/postgresql.yml
@@ -8,7 +8,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ postgresql_apt_preferences_dependent_list }}'
 
     - role: debops.postgresql

--- a/playbooks/service/postgresql_server.yml
+++ b/playbooks/service/postgresql_server.yml
@@ -18,7 +18,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ postgresql_server_ferm_dependent_rules }}'
 
     - role: debops.postgresql_server

--- a/playbooks/service/postgresql_server.yml
+++ b/playbooks/service/postgresql_server.yml
@@ -8,7 +8,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ postgresql_server_apt_preferences_dependent_list }}'
 
     - role: debops.etc_services

--- a/playbooks/service/postgresql_server.yml
+++ b/playbooks/service/postgresql_server.yml
@@ -13,7 +13,7 @@
 
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]
-      etc_services_dependent_list:
+      etc_services__dependent_list:
         - '{{ postgresql_server_etc_services_dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/slapd.yml
+++ b/playbooks/service/slapd.yml
@@ -8,7 +8,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ slapd_ferm_dependent_rules }}'
 
     - role: debops.tcpwrappers

--- a/playbooks/service/snmpd.yml
+++ b/playbooks/service/snmpd.yml
@@ -8,7 +8,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferencesA' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ snmpd_apt_preferences_dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/snmpd.yml
+++ b/playbooks/service/snmpd.yml
@@ -13,7 +13,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ snmpd_ferm_dependent_rules }}'
 
     - role: debops.tcpwrappers

--- a/playbooks/service/sshd.yml
+++ b/playbooks/service/sshd.yml
@@ -13,7 +13,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ sshd__ferm__dependent_rules }}'
 
     - role: debops.tcpwrappers

--- a/playbooks/service/sshd.yml
+++ b/playbooks/service/sshd.yml
@@ -8,7 +8,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list:
+      apt_preferences__dependent_list:
         - '{{ sshd__apt_preferences__dependent_list }}'
 
     - role: debops.ferm

--- a/playbooks/service/subnetwork.yml
+++ b/playbooks/service/subnetwork.yml
@@ -16,7 +16,7 @@
     - role: debops.ferm
       tags: [ 'role::ferm' ]
       ferm_forward: '{{ subnetwork__kernel_forwarding|d() | bool }}'
-      ferm_dependent_rules:
+      ferm__dependent_rules:
         - '{{ subnetwork__ferm__dependent_rules }}'
 
     - role: debops.subnetwork

--- a/playbooks/service/tinc.yml
+++ b/playbooks/service/tinc.yml
@@ -19,7 +19,7 @@
 
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]
-      etc_services_dependent_list: '{{ tinc__env_etc_services__dependent_list }}'
+      etc_services__dependent_list: '{{ tinc__env_etc_services__dependent_list }}'
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]

--- a/playbooks/service/tinc.yml
+++ b/playbooks/service/tinc.yml
@@ -15,7 +15,7 @@
 
     - role: debops.apt_preferences
       tags: [ 'role::apt_preferences' ]
-      apt_preferences_dependent_list: '{{ tinc__apt_preferences__dependent_list }}'
+      apt_preferences__dependent_list: '{{ tinc__apt_preferences__dependent_list }}'
 
     - role: debops.etc_services
       tags: [ 'role::etc_services' ]

--- a/playbooks/service/tinc.yml
+++ b/playbooks/service/tinc.yml
@@ -23,7 +23,7 @@
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]
-      ferm_dependent_rules: '{{ tinc__env_ferm__dependent_rules }}'
+      ferm__dependent_rules: '{{ tinc__env_ferm__dependent_rules }}'
 
     - role: debops.tinc
       tags: [ 'role::tinc' ]


### PR DESCRIPTION
Related to https://github.com/debops/ansible-apt/pull/54.