### PR TITLE
Renamed `apt_cacher_ng__nginx_upstream` to `apt_cacher_ng__nginx__upsream`.

### DIFF
--- a/playbooks/service/apt_cacher_ng.yml
+++ b/playbooks/service/apt_cacher_ng.yml
@@ -28,7 +28,7 @@
       nginx_servers:
         - '{{ apt_cacher_ng__nginx__servers }}'
       nginx_upstreams:
-        - '{{ apt_cacher_ng__nginx_upstream }}'
+        - '{{ apt_cacher_ng__nginx__upstream }}'
 
     # - role: debops.contrib-apparmor
     #   tags: [ 'role::apparmor' ]


### PR DESCRIPTION
Related to https://github.com/debops/ansible-apt_cacher_ng/pull/4