### PR TITLE
Run `debops.apt` earlier in the `common.yml` playbook.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,9 @@ v0.2.9
 - Update the ``service/postgresql.yml`` playbook to use new namespaced
   variables. [drybjed]
 
+- Run ``debops.apt`` earlier in the ``common.yml`` playbook to setup things
+  like APT proxy and :manpage:`sources.list(5)` for other roles. [ypid]
+
 v0.2.8
 ------
 

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -25,11 +25,6 @@
         - '{{ apt_install__apt_preferences__dependent_list }}'
         - '{{ rsyslog__apt_preferences__dependent_list }}'
 
-    - role: debops.etc_services
-      tags: [ 'role::etc_services' ]
-      etc_services__dependent_list:
-        - '{{ rsyslog__etc_services__dependent_list }}'
-
     - role: debops.atd
       tags: [ 'role::atd' ]
 
@@ -39,6 +34,17 @@
     - role: debops.pki
       tags: [ 'role::pki' ]
 
+    - role: debops.apt
+      tags: [ 'role::apt' ]
+
+    - role: debops.apt_install
+      tags: [ 'role::apt_install' ]
+
+    - role: debops.etc_services
+      tags: [ 'role::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ rsyslog__etc_services__dependent_list }}'
+
     - role: debops.logrotate
       tags: [ 'role::logrotate' ]
       logrotate__dependent_config:
@@ -46,12 +52,6 @@
 
     - role: debops.auth
       tags: [ 'role::auth' ]
-
-    - role: debops.apt
-      tags: [ 'role::apt' ]
-
-    - role: debops.apt_install
-      tags: [ 'role::apt_install' ]
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]


### PR DESCRIPTION
Closes #263.