### PR TITLE
Fixed up coding style for :regexp:`inventory__(?:group_|host_)?environment` usage.

### DIFF
--- a/docs/custom-environment.rst
+++ b/docs/custom-environment.rst
@@ -49,9 +49,9 @@ contain the following code:
      hosts: [ 'debops_service_custom' ]
      become: True
 
-     environment: '{{ (inventory__environment | d({}) |
-                       combine(inventory__group_environment | d({}) |
-                        combine(inventory__host_environment | d({})))) }}'
+     environment: '{{ inventory__environment | d({})
+                      | combine(inventory__group_environment | d({}))
+                      | combine(inventory__host_environment  | d({})) }}'
 
      roles:
 

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -33,9 +33,9 @@
   hosts: 'debops_all_hosts'
   gather_facts: False
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -7,9 +7,9 @@
   gather_facts: True
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/core.yml
+++ b/playbooks/core.yml
@@ -4,9 +4,9 @@
   hosts: 'debops_all_hosts'
   become: False
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/apt.yml
+++ b/playbooks/service/apt.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_apt' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/apt_cacher_ng.yml
+++ b/playbooks/service/apt_cacher_ng.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_apt_cacher_ng' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/apt_install.yml
+++ b/playbooks/service/apt_install.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_apt_install' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/apt_preferences.yml
+++ b/playbooks/service/apt_preferences.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_apt_preferences' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/atd.yml
+++ b/playbooks/service/atd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_atd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/auth.yml
+++ b/playbooks/service/auth.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_auth' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/boxbackup.yml
+++ b/playbooks/service/boxbackup.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_boxbackup', 'debops_boxbackup' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/console.yml
+++ b/playbooks/service/console.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_console' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/cryptsetup.yml
+++ b/playbooks/service/cryptsetup.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_cryptsetup' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/debops.yml
+++ b/playbooks/service/debops.yml
@@ -5,9 +5,9 @@
            'debops_recursively' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/dhcpd.yml
+++ b/playbooks/service/dhcpd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_dhcpd', 'debops_dhcpd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/dhparam.yml
+++ b/playbooks/service/dhparam.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_dhparam' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/dnsmasq.yml
+++ b/playbooks/service/dnsmasq.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_dnsmasq', 'debops_dnsmasq' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/docker.yml
+++ b/playbooks/service/docker.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_docker', 'debops_docker' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/docker_gen.yml
+++ b/playbooks/service/docker_gen.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_docker_gen', 'debops_docker_gen' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/dokuwiki.yml
+++ b/playbooks/service/dokuwiki.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_dokuwiki', 'debops_dokuwiki' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/dovecot.yml
+++ b/playbooks/service/dovecot.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_dovecot', 'debops_dovecot' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/elasticsearch.yml
+++ b/playbooks/service/elasticsearch.yml
@@ -9,9 +9,9 @@
            'debops_elasticsearch_coordinator', 'debops_elasticsearch_loadbalancer' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/etc_services.yml
+++ b/playbooks/service/etc_services.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_etc_services' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/etherpad.yml
+++ b/playbooks/service/etherpad.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_etherpad', 'debops_etherpad' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/fail2ban.yml
+++ b/playbooks/service/fail2ban.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_fail2ban', 'debops_fail2ban' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/fcgiwrap.yml
+++ b/playbooks/service/fcgiwrap.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_fcgiwrap', 'debops_fcgiwrap' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/ferm.yml
+++ b/playbooks/service/ferm.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_ferm' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/gitlab.yml
+++ b/playbooks/service/gitlab.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_gitlab', 'debops_gitlab' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/gitlab_ci.yml
+++ b/playbooks/service/gitlab_ci.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_gitlab_ci', 'debops_gitlab_ci' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/gitlab_ci_runner.yml
+++ b/playbooks/service/gitlab_ci_runner.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_gitlab_ci_runner', 'debops_gitlab_ci_runner' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/gitlab_runner.yml
+++ b/playbooks/service/gitlab_runner.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_gitlab_runner' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/gitusers.yml
+++ b/playbooks/service/gitusers.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_gitusers', 'debops_gitusers' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/golang.yml
+++ b/playbooks/service/golang.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_golang', 'debops_golang' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/grub.yml
+++ b/playbooks/service/grub.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_grub', 'debops_grub' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/hwraid.yml
+++ b/playbooks/service/hwraid.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_hwraid', 'debops_hwraid' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/ifupdown.yml
+++ b/playbooks/service/ifupdown.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_ifupdown' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/ipxe.yml
+++ b/playbooks/service/ipxe.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_ipxe', 'debops_ipxe' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/iscsi.yml
+++ b/playbooks/service/iscsi.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_iscsi', 'debops_iscsi' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/java.yml
+++ b/playbooks/service/java.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_java', 'debops_java' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/librenms.yml
+++ b/playbooks/service/librenms.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_librenms', 'debops_librenms' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/libvirt.yml
+++ b/playbooks/service/libvirt.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_libvirt', 'debops_libvirt' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/libvirtd.yml
+++ b/playbooks/service/libvirtd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_libvirtd', 'debops_libvirtd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/logrotate.yml
+++ b/playbooks/service/logrotate.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_logrotate' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/lvm.yml
+++ b/playbooks/service/lvm.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_lvm', 'debops_lvm' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/lxc.yml
+++ b/playbooks/service/lxc.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_lxc', 'debops_lxc' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/mailman.yml
+++ b/playbooks/service/mailman.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_mailman', 'debops_mailman' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/mariadb.yml
+++ b/playbooks/service/mariadb.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_mariadb', 'debops_mariadb' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/mariadb_server.yml
+++ b/playbooks/service/mariadb_server.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_mariadb_server', 'debops_mariadb_server' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/memcached.yml
+++ b/playbooks/service/memcached.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_memcached', 'debops_memcached' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/monit.yml
+++ b/playbooks/service/monit.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_monit', 'debops_monit' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/mysql.yml
+++ b/playbooks/service/mysql.yml
@@ -4,9 +4,9 @@
   hosts: 'debops_mysql'
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/nfs.yml
+++ b/playbooks/service/nfs.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_nfs', 'debops_nfs' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/nginx.yml
+++ b/playbooks/service/nginx.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_nginx', 'debops_nginx' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/nodejs.yml
+++ b/playbooks/service/nodejs.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_nodejs', 'debops_nodejs' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/ntp.yml
+++ b/playbooks/service/ntp.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_ntp' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/openvz.yml
+++ b/playbooks/service/openvz.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_openvz', 'debops_openvz' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/owncloud.yml
+++ b/playbooks/service/owncloud.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_owncloud', 'debops_owncloud' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/php5.yml
+++ b/playbooks/service/php5.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_php5', 'debops_php5' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/phpipam.yml
+++ b/playbooks/service/phpipam.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_phpipam', 'debops_phpipam' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/pki.yml
+++ b/playbooks/service/pki.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_pki' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/postfix.yml
+++ b/playbooks/service/postfix.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_postfix' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/postgresql.yml
+++ b/playbooks/service/postgresql.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_postgresql', 'debops_postgresql' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/postgresql_server.yml
+++ b/playbooks/service/postgresql_server.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_postgresql_server', 'debops_postgresql_server' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/preseed.yml
+++ b/playbooks/service/preseed.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_preseed' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/radvd.yml
+++ b/playbooks/service/radvd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_radvd', 'debops_radvd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/redis.yml
+++ b/playbooks/service/redis.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_redis', 'debops_redis' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 
@@ -18,9 +18,9 @@
   hosts: [ 'debops_service_redis_sentinel', 'debops_redis_sentinel' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/reprepro.yml
+++ b/playbooks/service/reprepro.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_reprepro', 'debops_reprepro' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/resources.yml
+++ b/playbooks/service/resources.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_resources' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/rsnapshot.yml
+++ b/playbooks/service/rsnapshot.yml
@@ -6,9 +6,9 @@
            'debops_rsnapshot', 'debops_rsnapshot_rsync' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/rstudio_server.yml
+++ b/playbooks/service/rstudio_server.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_rstudio_server', 'debops_rstudio_server' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/rsyslog.yml
+++ b/playbooks/service/rsyslog.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_rsyslog' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/ruby.yml
+++ b/playbooks/service/ruby.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_ruby', 'debops_ruby' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/salt.yml
+++ b/playbooks/service/salt.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_salt', 'debops_salt' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/samba.yml
+++ b/playbooks/service/samba.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_samba', 'debops_samba' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/sftpusers.yml
+++ b/playbooks/service/sftpusers.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_sftpusers', 'debops_sftpusers' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/sks.yml
+++ b/playbooks/service/sks.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_sks', 'debops_sks' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/slapd.yml
+++ b/playbooks/service/slapd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_slapd', 'debops_slapd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/smstools.yml
+++ b/playbooks/service/smstools.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_smstools', 'debops_smstools' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/snmpd.yml
+++ b/playbooks/service/snmpd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_snmpd', 'debops_snmpd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/sshd.yml
+++ b/playbooks/service/sshd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_sshd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/sshkeys.yml
+++ b/playbooks/service/sshkeys.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_sshkeys' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/stunnel.yml
+++ b/playbooks/service/stunnel.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_stunnel', 'debops_stunnel' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/subnetwork.yml
+++ b/playbooks/service/subnetwork.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_subnetwork', 'debops_subnetwork' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/swapfile.yml
+++ b/playbooks/service/swapfile.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_swapfile', 'debops_swapfile' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/tcpwrappers.yml
+++ b/playbooks/service/tcpwrappers.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_tcpwrappers' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/tftpd.yml
+++ b/playbooks/service/tftpd.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_tftpd', 'debops_tftpd' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/tgt.yml
+++ b/playbooks/service/tgt.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_tgt', 'debops_tgt' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/tinc.yml
+++ b/playbooks/service/tinc.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_service_tinc', 'debops_tinc' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/unattended_upgrades.yml
+++ b/playbooks/service/unattended_upgrades.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_unattended_upgrades' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 

--- a/playbooks/service/users.yml
+++ b/playbooks/service/users.yml
@@ -4,9 +4,9 @@
   hosts: [ 'debops_all_hosts', 'debops_service_users' ]
   become: True
 
-  environment: '{{ (inventory__environment | d({}) |
-                    combine(inventory__group_environment | d({}) |
-                     combine(inventory__host_environment | d({})))) }}'
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
 
   roles:
 


### PR DESCRIPTION
Advantages:

* Reduced use of parentheses.
* Looks better (alignment)

Command used to make all changes of this commit:

```Shell
git ls-files -z | xargs --null -I '{}' find '{}' -type f -print0 | xargs --null sed --in-place 's/(inventory__environment | d({}) |/inventory__environment | d({})/g;s/ combine(inventory__group_environment | d({}) |/| combine(inventory__group_environment | d({}))/g;s/  combine(inventory__host_environment | d({}))))/| combine(inventory__host_environment  | d({}))/g;'
```

Related to: #269