### PR TITLE
change 'sudo' to 'become' in comments and examples

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -26,7 +26,7 @@
 #
 # To connect as normal user and switch to sudo, run:
 #
-#     debops bootstrap --sudo --limit host
+#     debops bootstrap --become --limit host
 
 
 - name: Bootstrap Python support on a host

--- a/playbooks/library/database/ldap/ldap_attr.py
+++ b/playbooks/library/database/ldap/ldap_attr.py
@@ -115,12 +115,12 @@ options:
 EXAMPLES = """
 # Configure directory number 1 for example.com.
 - ldap_attr: dn='olcDatabase={1}hdb,cn=config' name=olcSuffix values='dc=example,dc=com' state=exact
-  sudo: true
+  become: true
 
 # Set up the ACL. The complex argument format is required here to pass a list
 # of ACL strings.
 - ldap_attr:
-  sudo: true
+  become: true
   args:
     dn: olcDatabase={1}hdb,cn=config
     name: olcAccess
@@ -137,14 +137,14 @@ EXAMPLES = """
 
 # Declare some indexes.
 - ldap_attr: dn='olcDatabase={1}hdb,cn=config' name=olcDbIndex values={{ item }}
-  sudo: true
+  become: true
   with_items:
     - objectClass eq
     - uid eq
 
 # Set up a root user, which we can use later to bootstrap the directory.
 - ldap_attr: dn='olcDatabase={1}hdb,cn=config' name={{ item.key }} values={{ item.value }} state=exact
-  sudo: true
+  become: true
   with_dict:
     olcRootDN: 'cn=root,dc=example,dc=com'
     olcRootPW: '{SSHA}mRskON0Stk+5wO5K+MMk2xmakKt8h7eJ'

--- a/playbooks/library/database/ldap/ldap_entry.py
+++ b/playbooks/library/database/ldap/ldap_entry.py
@@ -104,7 +104,7 @@ options:
 EXAMPLES = """
 # Make sure we have a parent entry for users.
 - ldap_entry: dn='ou=users,dc=example,dc=com' objectClass=organizationalUnit
-  sudo: true
+  become: true
 
 # Make sure we have an admin user.
 - ldap_entry:
@@ -112,7 +112,7 @@ EXAMPLES = """
     objectClass: simpleSecurityObject,organizationalRole
     description: An LDAP administrator
     userPassword: '{SSHA}pedsA5Y9wHbZ5R90pRdxTEZmn6qvPdzm'
-  sudo: true
+  become: true
 
 # Get rid of an old entry.
 - ldap_entry: dn='ou=stuff,dc=example,dc=com' state=absent server_uri='ldap://localhost/' bind_dn='cn=admin,dc=example,dc=com' bind_pw=password


### PR DESCRIPTION
A cleanup to change "sudo" to "become" in comments and examples.