### PR TITLE
Fix ferm configuration for hosts using libvirtd.

### DIFF
--- a/playbooks/service/libvirtd.yml
+++ b/playbooks/service/libvirtd.yml
@@ -18,6 +18,7 @@
     - role: debops.ferm
       tags: [ 'depend::ferm', 'type::dependency' ]
       ferm__forward: '{{ libvirtd__ferm__forward|d() | bool }}'
+      ferm__forward_accept: '{{ libvirtd__ferm__forward|d() | bool }}'
       ferm__dependent_rules:
         - '{{ libvirtd__ferm__dependent_rules }}'
 


### PR DESCRIPTION
libvirtd hosts need to forward packets, otherwise the hosted boxes
won't be able to speak with the outside world.