### PR TITLE
Adjust elasticsearch playbook to recent role updates

### DIFF
--- a/playbooks/service/elasticsearch.yml
+++ b/playbooks/service/elasticsearch.yml
@@ -15,6 +15,19 @@
 
   roles:
 
+    - role: debops.etc_services
+      tags: [ 'role::etc_services' ]
+      etc_services__dependent_list:
+        - '{{ elasticsearch__etc_services__dependent_list }}'
+
+    - role: debops.ferm
+      tags: [ 'role::ferm' ]
+      ferm__dependent_rules:
+        - '{{ elasticsearch__ferm__dependent_rules }}'
+
+    - role: debops.java
+      tags: [ 'role::java' ]
+
     - role: debops.elasticsearch
       tags: [ 'role::elasticsearch' ]
 


### PR DESCRIPTION
Role dependencies are not hard-coded anymore. See
debops/ansible-elasticsearch#12