### PR TITLE
Fix ownCloud Apache playbook

### DIFF
--- a/playbooks/app/owncloud-apache.yml
+++ b/playbooks/app/owncloud-apache.yml
@@ -1,0 +1,1 @@
+../service/owncloud-apache.yml

--- a/playbooks/app/owncloud-nginx.yml
+++ b/playbooks/app/owncloud-nginx.yml
@@ -1,0 +1,1 @@
+../service/owncloud-nginx.yml

--- a/playbooks/service/owncloud-nginx.yml
+++ b/playbooks/service/owncloud-nginx.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install and manage ownCloud instances with Apache as Nginx
+- name: Install and manage ownCloud instances with Nginx as webserver
   hosts: [ 'debops_service_owncloud', 'debops_service_owncloud_nginx' ]
   become: True
 

--- a/playbooks/service/owncloud.yml
+++ b/playbooks/service/owncloud.yml
@@ -1,1 +1,5 @@
-owncloud-nginx.yml
+---
+
+- include: owncloud-apache.yml
+
+- include: owncloud-nginx.yml


### PR DESCRIPTION
Prior, the Apache playbook was not run when calling `debops service/owncloud` or `debops app/owncloud`.

Nginx is still the default.