### PR TITLE
Update the debops.cryptsetup_ playbook to the new version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,8 @@ Changed
 
 - Update the debops.owncloud_ with Apache playbook to the new version. [ypid_]
 
+- Update the debops.cryptsetup_ playbook to the new version. [ypid_]
+
 Deprecated
 ~~~~~~~~~~
 

--- a/playbooks/service/cryptsetup-persistent_paths.yml
+++ b/playbooks/service/cryptsetup-persistent_paths.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Setup and manage encrypted filesystems and ensure persistence
+  hosts: [ 'debops_service_cryptsetup_persistent_paths' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.cryptsetup
+      tags: [ 'role::cryptsetup' ]
+
+    - role: debops.persistent_paths
+      tags: [ 'role::persistent_paths' ]
+      persistent_paths__dependent_paths: '{{ cryptsetup__persistent_paths__dependent_paths }}'

--- a/playbooks/service/cryptsetup-plain.yml
+++ b/playbooks/service/cryptsetup-plain.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Setup and manage encrypted filesystems
+  hosts: [ 'debops_service_cryptsetup' ]
+  become: True
+
+  environment: '{{ inventory__environment | d({})
+                   | combine(inventory__group_environment | d({}))
+                   | combine(inventory__host_environment  | d({})) }}'
+
+  roles:
+
+    - role: debops.cryptsetup
+      tags: [ 'role::cryptsetup' ]

--- a/playbooks/service/cryptsetup.yml
+++ b/playbooks/service/cryptsetup.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Setup and manage encrypted filesystems
-  hosts: [ 'debops_service_cryptsetup' ]
-  become: True
+- include: cryptsetup-plain.yml
 
-  environment: '{{ inventory__environment | d({})
-                   | combine(inventory__group_environment | d({}))
-                   | combine(inventory__host_environment  | d({})) }}'
-
-  roles:
-
-    - role: debops.cryptsetup
-      tags: [ 'role::cryptsetup' ]
+- include: cryptsetup-persistent_paths.yml

--- a/playbooks/sys/cryptsetup-persistent_paths.yml
+++ b/playbooks/sys/cryptsetup-persistent_paths.yml
@@ -1,0 +1,1 @@
+../service/cryptsetup-persistent_paths.yml

--- a/playbooks/sys/cryptsetup-plain.yml
+++ b/playbooks/sys/cryptsetup-plain.yml
@@ -1,0 +1,1 @@
+../service/cryptsetup-plain.yml


### PR DESCRIPTION
Related to: https://github.com/debops/ansible-cryptsetup/pull/23

I would propose that once a role has gotten more then one playbook, the plain/stripped down playbook gets renamed to `cryptsetup-plain.yml` (or a more precise name if there is one, see below) and a new `cryptsetup.yml` playbook gets created which includes all the role playbooks. This way, the user can still call the main/meta playbook and does not know which particular variant of the playbook is used for a particular host.
@drybjed Do you agree with this proposal?

Other examples: https://github.com/debops/ansible-owncloud/tree/master/docs/playbooks