### PR TITLE
Add commonly used set of Jinja2 macros to the repository

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,7 +104,7 @@ Changed
   library. These versions should work better with the latest Ansible 2.x
   releases. [drybjed_]
 
-- Update debops.ifupdown_ playbook to support new featurs in the role. You will
+- Update debops.ifupdown_ playbook to support new features in the role. You will
   need to update your inventory, check the role documentation for more details.
   [drybjed_]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,11 @@ Added
 
 - Add ``debops.persistent_paths`` role and its corresponding playbook. [ypid_]
 
+- Add commonly used set of Jinja2 macros to the repository under
+  `./templates/debops__tpl_macros.j2 <https://github.com/debops/debops-playbooks/blob/master/templates/debops__tpl_macros.j2>`_
+  to have a central place where the file can be maintained and from where the
+  latest version can be acquired. [ypid_]
+
 Changed
 ~~~~~~~
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,8 @@
 debops-playbooks - Set of Ansible playbooks for DebOps Project
 
-Copyright (C) 2013-2016 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2014-2016 DebOps https://debops.org/
+Copyright (C) 2013-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+Copyright (C) 2014-2017 DebOps https://debops.org/
 
 This repository is part of DebOps.
 

--- a/README.rst
+++ b/README.rst
@@ -54,9 +54,9 @@ Here are a few services that are available
 
 **Virtualization**
 
-+------+---------+---------+----------+
-| LXC_ | Docker_ | OpenVZ_ | libvirt_ |
-+------+---------+---------+----------+
++------+---------+----------+
+| LXC_ | Docker_ | libvirt_ |
++------+---------+----------+
 
 **Backup and encryption**
 
@@ -145,7 +145,6 @@ If you want to keep tabs on each role's status then check out our
 
 .. _LXC: https://github.com/debops/ansible-lxc
 .. _Docker: https://github.com/debops/ansible-docker
-.. _OpenVZ: https://github.com/debops/ansible-openvz
 .. _libvirt: https://github.com/debops/ansible-libvirt
 
 .. _Safekeep: https://github.com/debops/ansible-safekeep

--- a/templates/debops__tpl_macros.j2
+++ b/templates/debops__tpl_macros.j2
@@ -1,0 +1,131 @@
+{# vim: foldmarker=[[[,]]]:foldmethod=marker
+# Commonly used set of macros in DebOps.
+# It can be included in repositories as needed.
+# Changes to this file should go upstream: https://github.com/debops/debops-playbooks/blob/master/templates/debops__tpl_macros.j2
+#
+# Copyright [[[
+# =============
+#
+# Copyright (C) 2014-2017 Maciej Delmanowski <drybjed@drybjed.net>
+# Copyright (C) 2015-2017 Robin Schneider <ypid@riseup.net>
+# Copyright (C) 2014-2017 DebOps https://debops.org/
+#
+# This file is part of DebOps.
+#
+# DebOps is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# DebOps is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DebOps. If not, see https://www.gnu.org/licenses/.
+#
+# ]]]
+#
+# Usage [[[
+# =========
+#
+# Copy the template file into your ./templates/ path of a role where it fits
+# best. You can/might need to use symlinks to make the macros available from
+# different paths in your ./templates/ hierarchy.
+#
+# Make sure to retain the filename of this file so that automatic updates of
+# this file can be implemented.
+#
+# To use the macros in your own template, this file needs to be included like so:
+#
+# {% import 'debops__tpl_macros.j2' as debops__tpl_macros with context %}
+#
+# Then you can start using the macros like this:
+#
+# {{ debops__tpl_macros.indent(some_content, 4) }}
+#
+# ]]] #}
+
+{% macro get_yaml_list_for_elem(list_or_elem) %}{# [[[ #}
+{{ ([ list_or_elem ]
+    if (list_or_elem is string or list_or_elem in [True, False])
+    else (list_or_elem|list)) | to_nice_yaml }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_realm_yaml_list(domains, fallback_realm) %}{# [[[ #}
+{% set custom_realm_list = [] %}
+{% if domains and (ansible_local|d() and ansible_local.pki|d() and ansible_local.pki.known_realms|d()) %}
+{%   for domain in (get_yaml_list_for_elem(domains) | from_yaml) %}
+{%     if domain in ansible_local.pki.known_realms %}
+{%       set _ = custom_realm_list.append(domain) %}
+{%     elif (domain.split('.')[1:] | join('.')) in ansible_local.pki.known_realms %}
+{%       set _ = custom_realm_list.append(domain.split('.')[1:] | join('.')) %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+{% if custom_realm_list|length == 0 %}
+{%   set _ = custom_realm_list.append(fallback_realm) %}
+{% endif %}
+{{ custom_realm_list | to_nice_yaml }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_apache_version() %}{# [[[ #}
+{{ ansible_local.apache.version
+   if (ansible_local|d() and ansible_local.apache|d() and
+       ansible_local.apache.version|d())
+   else "2.4.0" -}}
+{% endmacro %}{# ]]] #}
+
+{% macro get_apache_min_version() %}{# [[[ #}
+{{ ansible_local.apache.min_version
+   if (ansible_local|d() and ansible_local.apache|d() and
+       ansible_local.apache.min_version|d())
+   else "2.4.0" -}}
+{% endmacro %}{# ]]] #}
+
+{% macro get_openssl_version() %}{# [[[ #}
+{{ ansible_local.pki.openssl_version
+   if (ansible_local|d() and ansible_local.pki|d() and
+       ansible_local.pki.openssl_version|d())
+   else "0.0.0" }}
+{% endmacro %}{# ]]] #}
+
+{% macro get_gnutls_version() %}{# [[[ #}
+{{ ansible_local.pki.gnutls_version
+   if (ansible_local|d() and ansible_local.pki|d() and
+       ansible_local.pki.gnutls_version|d())
+   else "0.0.0" }}
+{% endmacro %}{# ]]] #}
+
+{% macro indent(content, width=4, indentfirst=False) %}{# [[[ #}
+{# Fixed version of the `indent` filter which does not insert trailing spaces on empty lines.
+## Note that you can not use this macro like a filter but have to use it like a regular macro.
+## Example: {{ debops__tpl_macros.indent(some_content, 4) }}
+##
+## Python re.sub seems to default to re.MULTILINE in Ansible.
+#}
+{{ content | indent(width, indentfirst) | regex_replace("[ \\t\\r\\f\\v]+(\\n|$)", "\\1") -}}
+{% endmacro %}{# ]]] #}
+
+{% macro merge_dict(current_dict, to_merge_dict, dict_key='name') %}{# [[[ #}
+{%   set merged_dict = current_dict %}
+{%   if to_merge_dict %}
+{%     if to_merge_dict is mapping %}
+{%       for dict_name in to_merge_dict.keys() | sort %}
+{%         if to_merge_dict[dict_name][dict_key]|d() %}
+{%           set _ = merged_dict.update({to_merge_dict[dict_name][dict_key]:(current_dict[to_merge_dict[dict_name][dict_key]]|d({}) | combine(to_merge_dict[dict_name], recursive=True))}) %}
+{%         elif to_merge_dict[dict_name][dict_key] is undefined %}
+{%           set _ = merged_dict.update({dict_name:(current_dict[dict_name]|d({}) | combine(to_merge_dict[dict_name], recursive=True))}) %}
+{%         endif %}
+{%       endfor %}
+{%     elif to_merge_dict is not string and to_merge_dict is not mapping %}
+{%       set flattened_dict = lookup("flattened", to_merge_dict) %}
+{%       for element in ([ flattened_dict ] if flattened_dict is mapping else flattened_dict) %}
+{%         if element[dict_key]|d() %}
+{%           set _ = merged_dict.update({element[dict_key]:(current_dict[element[dict_key]]|d({}) | combine(element, recursive=True))}) %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{{ merged_dict | to_json }}
+{% endmacro %}{# ]]] #}


### PR DESCRIPTION
Reason: Needed because there are a few macros which currently get inlined/duplicated into the different role’s templates which is not really maintenance friendly. As you can see this as the versions of the `merge_dict` macro already differs slightly in [debops.ifupdown](https://github.com/debops/ansible-ifupdown/blob/master/templates/lookup/ifupdown__combined_interfaces.j2) and [debops.cron](https://github.com/debops/ansible-cron/blob/master/templates/lookup/cron__combined_jobs.j2). Such deviations can automatically be resolved by debops-optimize when there are common files which can be identified by filename and updated.