### PR TITLE
Revert commit 3ba3d39.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,26 +162,6 @@ Fixed
   Ansible 2.1. This is a non-backwards compatible change and it breaks
   compatibility with Ansible 2.0. [anzil]
 
-Security
-~~~~~~~~
-
-- Terminate playbook execution as soon as possible if a vulnerable Ansible version is used.
-  The minimum Ansible version without known vulnerabilities is Ansible 2.1.4.
-  The check is run as part of the :file:`common.yml` playbook file in a
-  separate playbook which has ``gather_facts`` explicitly turned of and the
-  task being delegated to the Ansible controller to avoid possible connection
-  attempts to remote hosts before the check had the opportunity to terminate
-  a vulnerable Ansible instance.
-  This playbook is run with no limitation on remote hosts meaning it will also
-  run the check even if the current Ansible run is limited to a host which is
-  not even managed by DebOps.
-  This check became necessary because some distributions only provide Ansible
-  versions with known vulnerabilities and some users are unaware.
-  Note that you will need `stable-2.1 <https://github.com/ansible/ansible/tree/stable-2.1>`_
-  because some required fixes for advanced templating features which DebOps
-  uses have not made it into v2.1.4 (broke while fixing the CVEs).
-  Refer to `Ansible Security`_ for details. [ypid_]
-
 
 `debops-playbooks v0.2.9`_ - 2016-07-07
 ---------------------------------------

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -1,22 +1,5 @@
 ---
 
-- name: Security assertions
-  hosts: [ 'all' ]
-  tags: [ 'play::security-assertions' ]
-  gather_facts: False
-  become: False
-
-  tasks:
-
-    - name: Check for Ansible version without known vulnerabilities
-      assert:
-        that:
-          - 'ansible_version.full | version_compare("2.1.4.0", ">=")'
-          - '((ansible_version.minor == 2) and (ansible_version.full | version_compare("2.2.1.0", ">="))) or (ansible_version.minor != 2)'
-        msg: 'VULNERABLE Ansible version DETECTED, please update Ansible to the stable-2.1 branch (> v2.1.4) or a newer Ansible release (>= v2.2.1)! Check the debops-playbook changelog for details. Exiting.'
-      run_once: True
-      delegate_to: 'localhost'
-
 - include: service/core.yml
 
 - name: Common configuration for all hosts


### PR DESCRIPTION
Don't check for vulnerable ansible versions, it's not debops' job
to make sure other packages don't have known vulnerabilities, but the
distribution's.

Furthermore, some distributions backport the security fixes without changing
the version, resulting in a false positive (Debian itself being one of those).