### PR TITLE
Require v2.1.5 or v2.2.2 instead of unreleased Ansible releases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,10 +183,10 @@ Security
   not even managed by DebOps.
   This check became necessary because some distributions only provide Ansible
   versions with known vulnerabilities and some users are unaware.
-  Note that you will need `stable-2.1 <https://github.com/ansible/ansible/tree/stable-2.1>`_
-  because some required fixes for advanced templating features which DebOps
-  uses have not made it into v2.1.4 (broke while fixing the CVEs).
-  Refer to `Ansible Security`_ for details. [ypid_]
+  Note that you will need v2.1.5 or v2.2.2 because some required fixes for
+  advanced templating features which DebOps uses have not made it into v2.1.4
+  (broke while fixing the CVEs).  Refer to `Ansible Security`_ for details.
+  [ypid_]
 
 
 `debops-playbooks v0.2.9`_ - 2016-07-07

--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -11,9 +11,9 @@
     - name: Check for Ansible version without known vulnerabilities
       assert:
         that:
-          - 'ansible_version.full | version_compare("2.1.4.0", ">=")'
-          - '((ansible_version.minor == 2) and (ansible_version.full | version_compare("2.2.1.0", ">="))) or (ansible_version.minor != 2)'
-        msg: 'VULNERABLE Ansible version DETECTED, please update Ansible to the stable-2.1 branch (> v2.1.4) or a newer Ansible release (>= v2.2.1)! To skip, add "--skip-tags play::security-assertions" parameter. Check the debops-playbook changelog for details. Exiting.'
+          - 'ansible_version.full | version_compare("2.1.5.0", ">=")'
+          - '((ansible_version.minor == 2) and (ansible_version.full | version_compare("2.2.2.0", ">="))) or (ansible_version.minor != 2)'
+        msg: 'VULNERABLE or unsupported Ansible version DETECTED, please update to Ansible >= v2.1.5 or a newer Ansible release >= v2.2.2! To skip, add "--skip-tags play::security-assertions" parameter. Check the debops-playbook changelog for details. Exiting.'
       run_once: True
       delegate_to: 'localhost'
 


### PR DESCRIPTION
The releases v2.1.4 and v2.2.1 did not fully support all DebOps roles which is why `s/stable-2\.[12]/` branches where required for the time being. Now that the latest versions of those branches have been released we can properly check for them.