### PR TITLE
Resources before Ferm

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -92,6 +92,9 @@
     - role: debops.nsswitch
       tags: [ 'role::nsswitch' ]
 
+    - role: debops.resources
+      tags: [ 'role::resources' ]
+
     - role: debops.ferm
       tags: [ 'role::ferm' ]
       ferm__dependent_rules:
@@ -135,9 +138,6 @@
 
     - role: debops.sshd
       tags: [ 'role::sshd' ]
-
-    - role: debops.resources
-      tags: [ 'role::resources' ]
 
     - role: debops.cron
       tags: [ 'role::cron' ]


### PR DESCRIPTION
The "resources" role should come before the role "ferm" so that it is possible to use in the rules the files that are written by the role "resources"