### PR TITLE
perform lvm task before nfs_server

### DIFF
--- a/playbooks/sys/all.yml
+++ b/playbooks/sys/all.yml
@@ -2,6 +2,8 @@
 
 - include: swapfile.yml
 
+- include: lvm.yml
+
 - include: nfs_server.yml
 
 - include: nfs.yml
@@ -11,8 +13,6 @@
 - include: sftpusers.yml
 
 - include: slapd.yml
-
-- include: lvm.yml
 
 - include: iscsi.yml
 


### PR DESCRIPTION
By performing LVM setup before nfs_server task,
user can share directory under LVM partition at once.

Signed-off-by: tharada <harada.tomoyuki03@gmail.com>