### PR TITLE
fix brace-mismatch in playbook

### DIFF
--- a/playbooks/service/librenms.yml
+++ b/playbooks/service/librenms.yml
@@ -23,7 +23,7 @@
       tags: [ 'role::logrotate' ]
       logrotate__dependent_config:
         - '{{ php__logrotate__dependent_config }}'
-        - '{{ librenms__logrotate__dependent_config }]'
+        - '{{ librenms__logrotate__dependent_config }}'
 
     - role: debops.ferm
       tags: [ 'role::ferm' ]


### PR DESCRIPTION
Signed-off-by: tharada <harada.tomoyuki03@gmail.com>

Brace-mismatch found in `playbooks/service/librenms.yml`, and this causes failure when configuring librenms service like below.

```
TASK [debops.logrotate : Divert the custom log rotation config] **********************************************************************************************
fatal: [nms.example.com]: FAILED! => {"failed": true, "msg": "[u'{{ php__logrotate__dependent_config }}', u'{{ librenms__logrotate__dependent_config }]']: template error while templating string: unexpected '}'. String: {{ librenms__logrotate__dependent_config }]"}
```

This commit just fixes the mismatch.